### PR TITLE
Add STDIN and STDOUT support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,7 @@ Below is the full listing of options::
     optional arguments:
       -h, --help            show this help message and exit
       -i, --in-place        make changes to files instead of printing diffs
+      -s, --stdout          print changed text to STDOUT
       -r, --recursive       drill down directories recursively
       --exclude globs       exclude file/directory names that match these comma-
                             separated globs

--- a/autoflake.py
+++ b/autoflake.py
@@ -619,6 +619,7 @@ def fix_code(source, additional_imports=None, expand_star_imports=False,
 
 def fix_file(filename, args, standard_out):
     """Run fix_code() on a file."""
+
     if filename == '-':
         input_file = sys.stdin
         source = input_file.read()

--- a/autoflake.py
+++ b/autoflake.py
@@ -637,10 +637,10 @@ def fix_file(filename, args, standard_out):
         remove_duplicate_keys=args.remove_duplicate_keys,
         remove_unused_variables=args.remove_unused_variables)
 
-    if original_source != filtered_source:
-        if args.stdout:
-            sys.stdout.write(filtered_source)
-        elif args.in_place and input_file != sys.stdin:
+    if args.stdout:
+        sys.stdout.write(filtered_source)
+    elif original_source != filtered_source:
+        if args.in_place and input_file != sys.stdin:
             with open_with_encoding(filename, mode='w',
                                     encoding=encoding) as output_file:
                 output_file.write(filtered_source)


### PR DESCRIPTION
If '-' is passed as a filename, read STDIN. If -s/--stdout is passed as a flag,
print formatted source to STDOUT. Useful for text editor integration.

See related pull request: https://github.com/myint/unify/pull/7