### PR TITLE
add supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ with open('README.rst') as readme:
                      'License :: OSI Approved :: MIT License',
                      'Programming Language :: Python :: 2.7',
                      'Programming Language :: Python :: 3',
+                     'Programming Language :: Python :: 3.6',
+                     'Programming Language :: Python :: 3.7',
                      'Topic :: Software Development :: Quality Assurance'],
         keywords='clean,fix,automatic,unused,import',
         py_modules=['autoflake'],


### PR DESCRIPTION
I just tested autoflake by using python  3.6 and 3.7 and there were no problem to work.
Could you add the supported python versions?