### PR TITLE
load config from pyproject.toml or setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ check=true
 imports=django,requests,urllib3
 ```
 
+The name of the configuration parameters match the flags (e.g. use the
+parameter `expand-star-imports` for the flag `--expand-star-imports`).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,25 @@ optional arguments:
 ```
 
 
+## Configuration
+
+Configure default arguments using a `pyproject.toml` file:
+
+```toml
+[tool.autoflake]
+check = true
+imports = ["django", "requests", "urllib3"]
+```
+
+Or a `setup.cfg` file:
+
+```ini
+[autoflake]
+check=true
+imports=django,requests,urllib3
+```
+
+
 ## Tests
 
 To run the unit tests::

--- a/autoflake.py
+++ b/autoflake.py
@@ -1074,13 +1074,15 @@ def merge_configuration_file(args):
 
     # Traverse the file tree common to all files given as argument looking for
     # a configuration file
-    config_path = os.path.commonpath([os.path.abspath(file)
-                                      for file in args.files])
+    config_path = os.path.commonpath([
+        os.path.abspath(file)
+        for file in args.files
+    ])
     config = None
     while True:
         for config_file, processor in CONFIG_FILES.items():
             config_file_path = os.path.join(
-                os.path.join(config_path, config_file)
+                os.path.join(config_path, config_file),
             )
             if os.path.isfile(config_file_path):
                 config = processor(config_file_path)
@@ -1104,7 +1106,7 @@ def merge_configuration_file(args):
                     _LOGGER.error(
                         "'%s' in the config file should be a comma separated"
                         " string or list of strings",
-                        name
+                        name,
                     )
                     return False
                 current_value = getattr(args, name, None)
@@ -1112,20 +1114,20 @@ def merge_configuration_file(args):
                     value = ",".join((value, current_value))
                 setattr(args, name, value)
             elif name in {
-                "check", "expand_star_imports", "ignore_init_module_imports",
-                "in_place", "recursive", "remove_all_unused_imports",
-                "remove_duplicate_keys", "remove_unused_variables",
+                "check", "expand-star-imports", "ignore-init-module-imports",
+                "in-place", "recursive", "remove-all-unused-imports",
+                "remove-duplicate-keys", "remove-unused-variables",
             }:
                 # boolean properties
                 if isinstance(value, str):
                     value = BOOL_TYPES.get(value, value)
                 if not isinstance(value, bool):
                     _LOGGER.error(
-                        "'%s' in the config file should be a boolean", name
+                        "'%s' in the config file should be a boolean", name,
                     )
                     return False
                 if value:
-                    setattr(args, name, value)
+                    setattr(args, name.replace("-", "_"), value)
             else:
                 _LOGGER.error("'%s' is not a valid configuration option", name)
                 return False

--- a/autoflake.py
+++ b/autoflake.py
@@ -1048,28 +1048,28 @@ def process_setup_cfg(cfg_file_path):
 
     reader = configparser.ConfigParser()
     reader.read(cfg_file_path)
-    if not reader.has_section("autoflake"):
+    if not reader.has_section('autoflake'):
         return None
 
-    return reader["autoflake"]
+    return reader['autoflake']
 
 
 def merge_configuration_file(args):
     """Merge configuration from a file into args."""
     # Configuration file parsers {filename: parser function}.
     CONFIG_FILES = {
-        "pyproject.toml": process_pyproject_toml,
-        "setup.cfg": process_setup_cfg,
+        'pyproject.toml': process_pyproject_toml,
+        'setup.cfg': process_setup_cfg,
     }
     BOOL_TYPES = {
-        "1": True,
-        "yes": True,
-        "true": True,
-        "on": True,
-        "0": False,
-        "no": False,
-        "false": False,
-        "off": False,
+        '1': True,
+        'yes': True,
+        'true': True,
+        'on': True,
+        '0': False,
+        'no': False,
+        'false': False,
+        'off': False,
     }
 
     # Traverse the file tree common to all files given as argument looking for
@@ -1096,27 +1096,27 @@ def merge_configuration_file(args):
     if config:
         # merge config
         for name, value in config.items():
-            if name in {"imports", "exclude"}:
+            if name in {'imports', 'exclude'}:
                 # comma separated list properties
                 if isinstance(value, list) and all(
                         isinstance(val, str) for val in value
                 ):
-                    value = ",".join(str(val) for val in value)
+                    value = ','.join(str(val) for val in value)
                 if not isinstance(value, str):
                     _LOGGER.error(
                         "'%s' in the config file should be a comma separated"
-                        " string or list of strings",
+                        ' string or list of strings',
                         name,
                     )
                     return False
                 current_value = getattr(args, name, None)
                 if current_value is not None:
-                    value = ",".join((value, current_value))
+                    value = ','.join((value, current_value))
                 setattr(args, name, value)
             elif name in {
-                "check", "expand-star-imports", "ignore-init-module-imports",
-                "in-place", "recursive", "remove-all-unused-imports",
-                "remove-duplicate-keys", "remove-unused-variables",
+                'check', 'expand-star-imports', 'ignore-init-module-imports',
+                'in-place', 'recursive', 'remove-all-unused-imports',
+                'remove-duplicate-keys', 'remove-unused-variables',
             }:
                 # boolean properties
                 if isinstance(value, str):
@@ -1127,7 +1127,7 @@ def merge_configuration_file(args):
                     )
                     return False
                 if value:
-                    setattr(args, name.replace("-", "_"), value)
+                    setattr(args, name.replace('-', '_'), value)
             else:
                 _LOGGER.error("'%s' is not a valid configuration option", name)
                 return False

--- a/autoflake.py
+++ b/autoflake.py
@@ -1074,7 +1074,8 @@ def merge_configuration_file(args):
 
     # Traverse the file tree common to all files given as argument looking for
     # a configuration file
-    config_path = os.path.commonpath([os.path.abspath(file) for file in args.files])
+    config_path = os.path.commonpath([os.path.abspath(file)
+                                      for file in args.files])
     config = None
     while True:
         for config_file, processor in CONFIG_FILES.items():

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ with open('README.md') as readme:
         entry_points={
             'console_scripts': ['autoflake = autoflake:main'],
         },
-        install_requires=['pyflakes>=1.1.0'],
+        install_requires=['pyflakes>=1.1.0', 'toml>=0.10.2'],
         test_suite='test_autoflake',
     )

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2628,7 +2628,7 @@ class MultilineFromImportTests(unittest.TestCase):
 
 class ConfigFileTest(unittest.TestCase):
     def __init__(self, methodName):
-        super(ConfigFileTest, self).__init__(methodName)
+        super().__init__(methodName)
         self.tmpdir = None
 
     def setUp(self):
@@ -2644,7 +2644,7 @@ class ConfigFileTest(unittest.TestCase):
             raise ValueError("Should not create an absolute test path")
         effective_path = os.path.sep.join([self.tmpdir, path])
         if not effective_path.startswith(
-                "{}{}".format(self.tmpdir, os.path.sep)
+                f"{self.tmpdir}{os.path.sep}"
         ) and (effective_path != self.tmpdir or is_file):
             raise ValueError("Should create a path within the tmp dir only")
         return effective_path

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2628,7 +2628,7 @@ class MultilineFromImportTests(unittest.TestCase):
 
 class ConfigFileTest(unittest.TestCase):
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="autoflake.")
+        self.tmpdir = tempfile.mkdtemp(prefix='autoflake.')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -2637,12 +2637,12 @@ class ConfigFileTest(unittest.TestCase):
     def effective_path(self, path, is_file=True):
         path = os.path.normpath(path)
         if os.path.isabs(path):
-            raise ValueError("Should not create an absolute test path")
+            raise ValueError('Should not create an absolute test path')
         effective_path = os.path.sep.join([self.tmpdir, path])
         if not effective_path.startswith(
-                f"{self.tmpdir}{os.path.sep}",
+                f'{self.tmpdir}{os.path.sep}',
         ) and (effective_path != self.tmpdir or is_file):
-            raise ValueError("Should create a path within the tmp dir only")
+            raise ValueError('Should create a path within the tmp dir only')
         return effective_path
 
     def create_dir(self, path):
@@ -2661,7 +2661,7 @@ class ConfigFileTest(unittest.TestCase):
                 self.create_dir(parent)
                 os.mkdir(effective_path)
 
-    def create_file(self, path, contents=""):
+    def create_file(self, path, contents=''):
         effective_path = self.effective_path(path)
         self.create_dir(os.path.split(path)[0])
         with open(effective_path, 'wt') as f:
@@ -2673,275 +2673,275 @@ class ConfigFileTest(unittest.TestCase):
         assert actual_props == expected_props
 
     def test_no_config_file(self):
-        self.create_file("test_me.py")
-        original_args = {"files": [self.effective_path("test_me.py")]}
+        self.create_file('test_me.py')
+        original_args = {'files': [self.effective_path('test_me.py')]}
         args = Namespace(**original_args)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(args, original_args)
 
     def test_non_nested_pyproject_toml_empty(self):
-        self.create_file("test_me.py")
-        self.create_file("pyproject.toml", "[tool.other]\nprop=\"value\"\n")
-        files = [self.effective_path("test_me.py")]
+        self.create_file('test_me.py')
+        self.create_file('pyproject.toml', "[tool.other]\nprop=\"value\"\n")
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
-        self.assert_namespace(args, {"files": files})
+        self.assert_namespace(args, {'files': files})
 
     def test_non_nested_pyproject_toml_non_empty(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports=true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports=true\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "expand_star_imports": True},
+            {'files': files, 'expand_star_imports': True},
         )
 
     def test_non_nested_setup_cfg_non_empty(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "setup.cfg",
-            "[other]\nexpand-star-imports = yes\n",
+            'setup.cfg',
+            '[other]\nexpand-star-imports = yes\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files},
+            {'files': files},
         )
 
     def test_non_nested_setup_cfg_empty(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "setup.cfg",
-            "[autoflake]\nexpand-star-imports = yes\n",
+            'setup.cfg',
+            '[autoflake]\nexpand-star-imports = yes\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "expand_star_imports": True},
+            {'files': files, 'expand_star_imports': True},
         )
 
     def test_nested_file(self):
-        self.create_file("nested/file/test_me.py")
+        self.create_file('nested/file/test_me.py')
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports=true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports=true\n',
         )
-        files = [self.effective_path("nested/file/test_me.py")]
+        files = [self.effective_path('nested/file/test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "expand_star_imports": True},
+            {'files': files, 'expand_star_imports': True},
         )
 
     def test_common_path_nested_file_do_not_load(self):
-        self.create_file("nested/file/test_me.py")
-        self.create_file("nested/other/test_me.py")
+        self.create_file('nested/file/test_me.py')
+        self.create_file('nested/other/test_me.py')
         self.create_file(
-            "nested/file/pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports=true\n",
+            'nested/file/pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports=true\n',
         )
         files = [
-            self.effective_path("nested/file/test_me.py"),
-            self.effective_path("nested/other/test_me.py"),
+            self.effective_path('nested/file/test_me.py'),
+            self.effective_path('nested/other/test_me.py'),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files},
+            {'files': files},
         )
 
     def test_common_path_nested_file_do_load(self):
-        self.create_file("nested/file/test_me.py")
-        self.create_file("nested/other/test_me.py")
+        self.create_file('nested/file/test_me.py')
+        self.create_file('nested/other/test_me.py')
         self.create_file(
-            "nested/pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports=true\n",
+            'nested/pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports=true\n',
         )
         files = [
-            self.effective_path("nested/file/test_me.py"),
-            self.effective_path("nested/other/test_me.py"),
+            self.effective_path('nested/file/test_me.py'),
+            self.effective_path('nested/other/test_me.py'),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "expand_star_imports": True},
+            {'files': files, 'expand_star_imports': True},
         )
 
     def test_common_path_instead_of_common_prefix(self):
         """Using common prefix would result in a failure."""
-        self.create_file("nested/file-foo/test_me.py")
-        self.create_file("nested/file-bar/test_me.py")
+        self.create_file('nested/file-foo/test_me.py')
+        self.create_file('nested/file-bar/test_me.py')
         self.create_file(
-            "nested/file/pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports=true\n",
+            'nested/file/pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports=true\n',
         )
         files = [
-            self.effective_path("nested/file-foo/test_me.py"),
-            self.effective_path("nested/file-bar/test_me.py"),
+            self.effective_path('nested/file-foo/test_me.py'),
+            self.effective_path('nested/file-bar/test_me.py'),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files},
+            {'files': files},
         )
 
     def test_continue_search_if_no_config_found(self):
-        self.create_file("nested/test_me.py")
+        self.create_file('nested/test_me.py')
         self.create_file(
-            "nested/pyproject.toml",
+            'nested/pyproject.toml',
             "[tool.other]\nprop = \"value\"\n",
         )
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports = true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports = true\n',
         )
-        files = [self.effective_path("nested/test_me.py")]
+        files = [self.effective_path('nested/test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "expand_star_imports": True},
+            {'files': files, 'expand_star_imports': True},
         )
 
     def test_stop_search_if_config_found(self):
-        self.create_file("nested/test_me.py")
+        self.create_file('nested/test_me.py')
         self.create_file(
-            "nested/pyproject.toml",
-            "[tool.autoflake]\n",
+            'nested/pyproject.toml',
+            '[tool.autoflake]\n',
         )
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nexpand-star-imports = true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nexpand-star-imports = true\n',
         )
-        files = [self.effective_path("nested/test_me.py")]
+        files = [self.effective_path('nested/test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files},
+            {'files': files},
         )
 
     def test_dont_load_false(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "setup.cfg",
-            "[autoflake]\nexpand-star-imports = no\n",
+            'setup.cfg',
+            '[autoflake]\nexpand-star-imports = no\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files},
+            {'files': files},
         )
 
     def test_list_value_pyproject_toml(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
+            'pyproject.toml',
             "[tool.autoflake]\nimports=[\"my_lib\", \"other_lib\"]\n",
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "imports": "my_lib,other_lib"},
+            {'files': files, 'imports': 'my_lib,other_lib'},
         )
 
     def test_list_value_comma_sep_string_pyproject_toml(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
+            'pyproject.toml',
             "[tool.autoflake]\nimports=\"my_lib,other_lib\"\n",
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "imports": "my_lib,other_lib"},
+            {'files': files, 'imports': 'my_lib,other_lib'},
         )
 
     def test_list_value_setup_cfg(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "setup.cfg",
-            "[autoflake]\nimports=my_lib,other_lib\n",
+            'setup.cfg',
+            '[autoflake]\nimports=my_lib,other_lib\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "imports": "my_lib,other_lib"},
+            {'files': files, 'imports': 'my_lib,other_lib'},
         )
 
     def test_unknown_property(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nunknown_prop=true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nunknown_prop=true\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert not autoflake.merge_configuration_file(args)
 
     def test_non_bool_value_for_bool_property(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
+            'pyproject.toml',
             "[tool.autoflake]\nexpand-star-imports=\"invalid\"\n",
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert not autoflake.merge_configuration_file(args)
 
     def test_non_bool_value_for_bool_property_in_setup_cfg(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "setup.cfg",
-            "[autoflake]\nexpand-star-imports=ok\n",
+            'setup.cfg',
+            '[autoflake]\nexpand-star-imports=ok\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert not autoflake.merge_configuration_file(args)
 
     def test_non_list_value_for_list_property(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
-            "[tool.autoflake]\nexclude=true\n",
+            'pyproject.toml',
+            '[tool.autoflake]\nexclude=true\n',
         )
-        files = [self.effective_path("test_me.py")]
+        files = [self.effective_path('test_me.py')]
         args = Namespace(files=files)
         assert not autoflake.merge_configuration_file(args)
 
     def test_merge_with_cli_set_list_property(self):
-        self.create_file("test_me.py")
+        self.create_file('test_me.py')
         self.create_file(
-            "pyproject.toml",
+            'pyproject.toml',
             "[tool.autoflake]\nimports=[\"my_lib\"]\n",
         )
-        files = [self.effective_path("test_me.py")]
-        args = Namespace(files=files, imports="other_lib")
+        files = [self.effective_path('test_me.py')]
+        args = Namespace(files=files, imports='other_lib')
         assert autoflake.merge_configuration_file(args)
         self.assert_namespace(
             args,
-            {"files": files, "imports": "my_lib,other_lib"},
+            {'files': files, 'imports': 'my_lib,other_lib'},
         )
 
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from argparse import Namespace
 
 import autoflake
 
@@ -2622,6 +2623,329 @@ class MultilineFromImportTests(unittest.TestCase):
             '    lib1, \\\n'
             '    lib3\n',
             remove_all=False,
+        )
+
+
+class ConfigFileTest(unittest.TestCase):
+    def __init__(self, methodName):
+        super(ConfigFileTest, self).__init__(methodName)
+        self.tmpdir = None
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="autoflake.")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+        self.tmpdir = None
+
+    def effective_path(self, path, is_file=True):
+        path = os.path.normpath(path)
+        if os.path.isabs(path):
+            raise ValueError("Should not create an absolute test path")
+        effective_path = os.path.sep.join([self.tmpdir, path])
+        if not effective_path.startswith(
+                "{}{}".format(self.tmpdir, os.path.sep)
+        ) and (effective_path != self.tmpdir or is_file):
+            raise ValueError("Should create a path within the tmp dir only")
+        return effective_path
+
+    def create_dir(self, path):
+        effective_path = self.effective_path(path, False)
+        if sys.version_info >= (3, 2, 0):
+            os.makedirs(effective_path, exist_ok=True)
+        else:
+            if os.path.exists(effective_path):
+                return
+            try:
+                os.mkdir(effective_path)
+            except OSError:
+                parent = os.path.split(path)[0]
+                if not parent:
+                    raise
+                self.create_dir(parent)
+                os.mkdir(effective_path)
+
+    def create_file(self, path, contents=""):
+        effective_path = self.effective_path(path)
+        self.create_dir(os.path.split(path)[0])
+        with open(effective_path, 'wt') as f:
+            f.write(contents)
+
+    def assert_namespace(self, namespace, expected_props):
+        keys = (prop for prop in dir(namespace) if not prop.startswith('_'))
+        actual_props = {key: getattr(namespace, key) for key in keys}
+        assert actual_props == expected_props
+
+    def test_no_config_file(self):
+        self.create_file("test_me.py")
+        original_args = {"files": [self.effective_path("test_me.py")]}
+        args = Namespace(**original_args)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(args, original_args)
+
+    def test_non_nested_pyproject_toml_empty(self):
+        self.create_file("test_me.py")
+        self.create_file("pyproject.toml", "[tool.other]\nprop=\"value\"\n")
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(args, {"files": files})
+
+    def test_non_nested_pyproject_toml_non_empty(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=true\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "expand_star_imports": True},
+        )
+
+    def test_non_nested_setup_cfg_non_empty(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "setup.cfg",
+            "[other]\nexpand_star_imports = yes\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files},
+        )
+
+    def test_non_nested_setup_cfg_empty(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "setup.cfg",
+            "[autoflake]\nexpand_star_imports = yes\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "expand_star_imports": True},
+        )
+
+    def test_nested_file(self):
+        self.create_file("nested/file/test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=true\n",
+        )
+        files = [self.effective_path("nested/file/test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "expand_star_imports": True},
+        )
+
+    def test_common_path_nested_file_do_not_load(self):
+        self.create_file("nested/file/test_me.py")
+        self.create_file("nested/other/test_me.py")
+        self.create_file(
+            "nested/file/pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=true\n",
+        )
+        files = [
+            self.effective_path("nested/file/test_me.py"),
+            self.effective_path("nested/other/test_me.py")
+        ]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files},
+        )
+
+    def test_common_path_nested_file_do_load(self):
+        self.create_file("nested/file/test_me.py")
+        self.create_file("nested/other/test_me.py")
+        self.create_file(
+            "nested/pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=true\n",
+        )
+        files = [
+            self.effective_path("nested/file/test_me.py"),
+            self.effective_path("nested/other/test_me.py")
+        ]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "expand_star_imports": True},
+        )
+
+    def test_common_path_instead_of_common_prefix(self):
+        """Using common prefix would result in a failure."""
+        self.create_file("nested/file-foo/test_me.py")
+        self.create_file("nested/file-bar/test_me.py")
+        self.create_file(
+            "nested/file/pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=true\n",
+        )
+        files = [
+            self.effective_path("nested/file-foo/test_me.py"),
+            self.effective_path("nested/file-bar/test_me.py")
+        ]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files},
+        )
+
+    def test_continue_search_if_no_config_found(self):
+        self.create_file("nested/test_me.py")
+        self.create_file(
+            "nested/pyproject.toml",
+            "[tool.other]\nprop = \"value\"\n",
+        )
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports = true\n",
+        )
+        files = [self.effective_path("nested/test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "expand_star_imports": True},
+        )
+
+    def test_stop_search_if_config_found(self):
+        self.create_file("nested/test_me.py")
+        self.create_file(
+            "nested/pyproject.toml",
+            "[tool.autoflake]\n",
+        )
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports = true\n",
+        )
+        files = [self.effective_path("nested/test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files},
+        )
+
+    def test_dont_load_false(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "setup.cfg",
+            "[autoflake]\nexpand_star_imports = no\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files},
+        )
+
+    def test_list_value_pyproject_toml(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nimports=[\"my_lib\", \"other_lib\"]\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "imports": "my_lib,other_lib"},
+        )
+
+    def test_list_value_comma_sep_string_pyproject_toml(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nimports=\"my_lib,other_lib\"\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "imports": "my_lib,other_lib"},
+        )
+
+    def test_list_value_setup_cfg(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "setup.cfg",
+            "[autoflake]\nimports=my_lib,other_lib\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "imports": "my_lib,other_lib"},
+        )
+
+    def test_unknown_property(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nunknown_prop=true\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert not autoflake.merge_configuration_file(args)
+
+    def test_non_bool_value_for_bool_property(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexpand_star_imports=\"invalid\"\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert not autoflake.merge_configuration_file(args)
+
+    def test_non_bool_value_for_bool_property_in_setup_cfg(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "setup.cfg",
+            "[autoflake]\nexpand_star_imports=ok\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert not autoflake.merge_configuration_file(args)
+
+    def test_non_list_value_for_list_property(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nexclude=true\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files)
+        assert not autoflake.merge_configuration_file(args)
+
+    def test_merge_with_cli_set_list_property(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\nimports=[\"my_lib\"]\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(files=files, imports="other_lib")
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {"files": files, "imports": "my_lib,other_lib"},
         )
 
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2627,10 +2627,6 @@ class MultilineFromImportTests(unittest.TestCase):
 
 
 class ConfigFileTest(unittest.TestCase):
-    def __init__(self, methodName):
-        super().__init__(methodName)
-        self.tmpdir = None
-
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="autoflake.")
 
@@ -2644,7 +2640,7 @@ class ConfigFileTest(unittest.TestCase):
             raise ValueError("Should not create an absolute test path")
         effective_path = os.path.sep.join([self.tmpdir, path])
         if not effective_path.startswith(
-                f"{self.tmpdir}{os.path.sep}"
+                f"{self.tmpdir}{os.path.sep}",
         ) and (effective_path != self.tmpdir or is_file):
             raise ValueError("Should create a path within the tmp dir only")
         return effective_path
@@ -2695,7 +2691,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=true\n",
+            "[tool.autoflake]\nexpand-star-imports=true\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)
@@ -2709,7 +2705,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "setup.cfg",
-            "[other]\nexpand_star_imports = yes\n",
+            "[other]\nexpand-star-imports = yes\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)
@@ -2723,7 +2719,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "setup.cfg",
-            "[autoflake]\nexpand_star_imports = yes\n",
+            "[autoflake]\nexpand-star-imports = yes\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)
@@ -2737,7 +2733,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("nested/file/test_me.py")
         self.create_file(
             "pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=true\n",
+            "[tool.autoflake]\nexpand-star-imports=true\n",
         )
         files = [self.effective_path("nested/file/test_me.py")]
         args = Namespace(files=files)
@@ -2752,11 +2748,11 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("nested/other/test_me.py")
         self.create_file(
             "nested/file/pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=true\n",
+            "[tool.autoflake]\nexpand-star-imports=true\n",
         )
         files = [
             self.effective_path("nested/file/test_me.py"),
-            self.effective_path("nested/other/test_me.py")
+            self.effective_path("nested/other/test_me.py"),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
@@ -2770,11 +2766,11 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("nested/other/test_me.py")
         self.create_file(
             "nested/pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=true\n",
+            "[tool.autoflake]\nexpand-star-imports=true\n",
         )
         files = [
             self.effective_path("nested/file/test_me.py"),
-            self.effective_path("nested/other/test_me.py")
+            self.effective_path("nested/other/test_me.py"),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
@@ -2789,11 +2785,11 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("nested/file-bar/test_me.py")
         self.create_file(
             "nested/file/pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=true\n",
+            "[tool.autoflake]\nexpand-star-imports=true\n",
         )
         files = [
             self.effective_path("nested/file-foo/test_me.py"),
-            self.effective_path("nested/file-bar/test_me.py")
+            self.effective_path("nested/file-bar/test_me.py"),
         ]
         args = Namespace(files=files)
         assert autoflake.merge_configuration_file(args)
@@ -2810,7 +2806,7 @@ class ConfigFileTest(unittest.TestCase):
         )
         self.create_file(
             "pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports = true\n",
+            "[tool.autoflake]\nexpand-star-imports = true\n",
         )
         files = [self.effective_path("nested/test_me.py")]
         args = Namespace(files=files)
@@ -2828,7 +2824,7 @@ class ConfigFileTest(unittest.TestCase):
         )
         self.create_file(
             "pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports = true\n",
+            "[tool.autoflake]\nexpand-star-imports = true\n",
         )
         files = [self.effective_path("nested/test_me.py")]
         args = Namespace(files=files)
@@ -2842,7 +2838,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "setup.cfg",
-            "[autoflake]\nexpand_star_imports = no\n",
+            "[autoflake]\nexpand-star-imports = no\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)
@@ -2908,7 +2904,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "pyproject.toml",
-            "[tool.autoflake]\nexpand_star_imports=\"invalid\"\n",
+            "[tool.autoflake]\nexpand-star-imports=\"invalid\"\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)
@@ -2918,7 +2914,7 @@ class ConfigFileTest(unittest.TestCase):
         self.create_file("test_me.py")
         self.create_file(
             "setup.cfg",
-            "[autoflake]\nexpand_star_imports=ok\n",
+            "[autoflake]\nexpand-star-imports=ok\n",
         )
         files = [self.effective_path("test_me.py")]
         args = Namespace(files=files)


### PR DESCRIPTION
Simple implementation for the currently missing functionality to load configuration from certain files:
- [x] pyproject.toml
- [x] setup.cfg (closes #68)

to do:
- [x] pytests
