### PR TITLE
Write newline before exit

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -836,7 +836,7 @@ def fix_file(filename, args, standard_out):
     if original_source != filtered_source:
         if args.check:
             standard_out.write(
-                '{filename}: Unused imports/variables detected'.format(
+                '{filename}: Unused imports/variables detected\n'.format(
                     filename=filename))
             sys.exit(1)
         if args.in_place:


### PR DESCRIPTION
Small change to add a new line before exiting when `--check` is used.