### PR TITLE
Added --quiet option to suppress no issues

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -851,7 +851,7 @@ def fix_file(filename, args, standard_out):
                 filename)
             standard_out.write(''.join(diff))
     else:
-        if args.check:
+        if args.check and not args.quiet:
             standard_out.write('No issues detected!\n')
         else:
             _LOGGER.debug('Clean %s: nothing to fix', filename)
@@ -1024,6 +1024,8 @@ def _main(argv, standard_out, standard_error):
                         help='remove unused variables')
     parser.add_argument('--version', action='version',
                         version='%(prog)s ' + __version__)
+    parser.add_argument('--quiet', action='store_true',
+                        help='Suppress output if there are no issues')
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         default=0, help='print more verbose logs (you can '
                                         'repeat `-v` to make it more verbose)')

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1409,6 +1409,19 @@ print(x)
                             standard_error=None)
             self.assertEqual('No issues detected!\n', output_file.getvalue())
 
+    def test_check_correct_file_with_quiet(self):
+        with temporary_file("""\
+import foo
+x = foo.bar
+print(x)
+""") as filename:
+            output_file = io.StringIO()
+            autoflake._main(argv=['my_fake_program', '--check', '--quiet',
+                                  filename],
+                            standard_out=output_file,
+                            standard_error=None)
+            self.assertEqual('', output_file.getvalue())
+
     def test_check_useless_pass(self):
         with temporary_file("""\
 import foo


### PR DESCRIPTION
Added `--quiet` option, so that when `check`ing lots of python files which are ok you don't get all those success messages printed. Other option could be to emit that no issues only with `--verbose`, but modifying existing things could break stuff