### PR TITLE
Add support for reading the file contents from stdin

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -806,8 +806,13 @@ def fix_file(filename, args, standard_out):
     """Run fix_code() on a file."""
     encoding = detect_encoding(filename)
     with open_with_encoding(filename, encoding=encoding) as input_file:
-        source = input_file.read()
+        return _fix_file(input_file, filename, args, args.write_to_stdout,
+                         standard_out, encoding=encoding)
 
+
+def _fix_file(input_file, filename, args, write_to_stdout, standard_out,
+              encoding=None):
+    source = input_file.read()
     original_source = source
 
     isInitFile = os.path.basename(filename) == '__init__.py'
@@ -833,7 +838,9 @@ def fix_file(filename, args, standard_out):
                 '{filename}: Unused imports/variables detected\n'.format(
                     filename=filename))
             sys.exit(1)
-        if args.in_place:
+        if write_to_stdout:
+            standard_out.write(filtered_source)
+        elif args.in_place:
             with open_with_encoding(filename, mode='w',
                                     encoding=encoding) as output_file:
                 output_file.write(filtered_source)
@@ -844,6 +851,8 @@ def fix_file(filename, args, standard_out):
                 io.StringIO(filtered_source).readlines(),
                 filename)
             standard_out.write(''.join(diff))
+    elif write_to_stdout:
+        standard_out.write(filtered_source)
     else:
         if args.check and not args.quiet:
             standard_out.write('No issues detected!\n')
@@ -908,7 +917,7 @@ def get_diff_text(old, new, filename):
 
 def _split_comma_separated(string):
     """Return a set of strings."""
-    return set(text.strip() for text in string.split(',') if text.strip())
+    return {text.strip() for text in string.split(',') if text.strip()}
 
 
 def is_python_file(filename):
@@ -980,7 +989,7 @@ def find_files(filenames, recursive, exclude):
                 _LOGGER.debug('Skipped %s: matched to exclude pattern', name)
 
 
-def _main(argv, standard_out, standard_error):
+def _main(argv, standard_out, standard_error, standard_input=None):
     """Return exit status.
 
     0 means no error.
@@ -989,8 +998,6 @@ def _main(argv, standard_out, standard_error):
     parser = argparse.ArgumentParser(description=__doc__, prog='autoflake')
     parser.add_argument('-c', '--check', action='store_true',
                         help='return error code if changes are needed')
-    parser.add_argument('-i', '--in-place', action='store_true',
-                        help='make changes to files instead of printing diffs')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
     parser.add_argument('--exclude', metavar='globs',
@@ -1023,7 +1030,18 @@ def _main(argv, standard_out, standard_error):
     parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
                         default=0, help='print more verbose logs (you can '
                                         'repeat `-v` to make it more verbose)')
+    parser.add_argument('--stdin-display-name', dest='stdin_display_name',
+                        default='stdin',
+                        help='the name used when processing input from stdin')
     parser.add_argument('files', nargs='+', help='files to format')
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-i', '--in-place', action='store_true',
+                       help='make changes to files instead of printing diffs')
+    group.add_argument('-s', '--stdout', action='store_true',
+                       dest='write_to_stdout',
+                       help=('print changed text to stdout. defaults to true '
+                             'when formatting stdin, or to false otherwise'))
 
     args = parser.parse_args(argv[1:])
 
@@ -1045,16 +1063,21 @@ def _main(argv, standard_out, standard_error):
     if args.exclude:
         args.exclude = _split_comma_separated(args.exclude)
     else:
-        args.exclude = set([])
+        args.exclude = set()
 
     filenames = list(set(args.files))
     failure = False
     for name in find_files(filenames, args.recursive, args.exclude):
-        try:
-            fix_file(name, args=args, standard_out=standard_out)
-        except IOError as exception:
-            _LOGGER.error(unicode(exception))
-            failure = True
+        if name == '-':
+            _fix_file(standard_input, args.stdin_display_name,
+                      args=args, write_to_stdout=True,
+                      standard_out=standard_out)
+        else:
+            try:
+                fix_file(name, args=args, standard_out=standard_out)
+            except IOError as exception:
+                _LOGGER.error(unicode(exception))
+                failure = True
 
     return 1 if failure else 0
 
@@ -1071,7 +1094,8 @@ def main():
     try:
         return _main(sys.argv,
                      standard_out=sys.stdout,
-                     standard_error=sys.stderr)
+                     standard_error=sys.stderr,
+                     standard_input=sys.stdin)
     except KeyboardInterrupt:  # pragma: no cover
         return 2  # pragma: no cover
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1520,6 +1520,16 @@ import os
 
         self.assertIn('redundant', output_file.getvalue())
 
+    def test_in_place_and_stdout(self):
+        output_file = io.StringIO()
+        self.assertRaises(
+            SystemExit,
+            autoflake._main,
+            argv=['my_fake_program', '--in-place', '--stdout', __file__],
+            standard_out=output_file,
+            standard_error=output_file,
+        )
+
     def test_end_to_end(self):
         with temporary_file("""\
 import fake_fake, fake_foo, fake_bar, fake_zoo
@@ -1663,6 +1673,42 @@ print(x)
             self.assertIn(
                 'redundant',
                 process.communicate()[1].decode())
+
+    def test_end_to_end_from_stdin(self):
+        stdin_data = b"""\
+import fake_fake, fake_foo, fake_bar, fake_zoo
+import re, os
+x = os.sep
+print(x)
+"""
+        process = subprocess.Popen(AUTOFLAKE_COMMAND +
+                                   ['--remove-all', '-'],
+                                   stdout=subprocess.PIPE,
+                                   stdin=subprocess.PIPE)
+        stdout, _ = process.communicate(stdin_data)
+        self.assertEqual("""\
+import os
+x = os.sep
+print(x)
+""", stdout.decode())
+
+    def test_end_to_end_from_stdin_with_in_place(self):
+        stdin_data = b"""\
+import fake_fake, fake_foo, fake_bar, fake_zoo
+import re, os, sys
+x = os.sep
+print(x)
+"""
+        process = subprocess.Popen(AUTOFLAKE_COMMAND +
+                                   ['--remove-all', '--in-place', '-'],
+                                   stdout=subprocess.PIPE,
+                                   stdin=subprocess.PIPE)
+        stdout, _ = process.communicate(stdin_data)
+        self.assertEqual("""\
+import os
+x = os.sep
+print(x)
+""", stdout.decode())
 
 
 class MultilineFromImportTests(unittest.TestCase):


### PR DESCRIPTION
Whenever that's set, the full output is always going to get printed to
stdout.

This is mainly intended for integration with editors, but it's made in a
way that is compatible with previous setups.

This includes a flag for the file name, I'm using `--stdin-display-name`
which matches what flake8 uses.

Closes #12.
Closes #37.