### PR TITLE
Drop old code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,10 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py37-plus

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ with open('README.md') as readme:
         license='Expat License',
         author='Steven Myint',
         url='https://github.com/myint/autoflake',
+        python_requires='>=3.7',
         classifiers=['Environment :: Console',
                      'Intended Audience :: Developers',
                      'License :: OSI Approved :: MIT License',

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 """Test suite for autoflake."""
 import contextlib
 import functools
@@ -2007,7 +2006,7 @@ class MultilineFromImportTests(unittest.TestCase):
             '\n'
         )
 
-        self.unused = ['lib{}.x.y.z'.format(x) for x in (1, 3, 4)]
+        self.unused = [f'lib{x}.x.y.z' for x in (1, 3, 4)]
         self.assert_fix([
             'import \\\n',
             '    lib1.x.y.z \\',
@@ -2201,7 +2200,7 @@ def temporary_directory(directory='.', prefix='tmp.'):
         shutil.rmtree(temp_directory)
 
 
-class StubFile(object):
+class StubFile:
 
     """Fake file that ignores everything."""
 

--- a/test_fuzz.py
+++ b/test_fuzz.py
@@ -25,12 +25,6 @@ else:
     END = ''
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
-
-
 def colored(text, color):
     """Return color coded text."""
     return color + text + END
@@ -106,7 +100,7 @@ def run(filename, command, verbose=False, options=None):
             if file_diff and after_count > before_count:
                 sys.stderr.write('autoflake made ' + filename + ' worse\n')
                 return False
-        except IOError as exception:
+        except OSError as exception:
             sys.stderr.write(str(exception) + '\n')
 
     return True
@@ -209,7 +203,7 @@ def check(args):
                 completed_filenames.update(name)
 
             if os.path.isdir(name):
-                for root, directories, children in os.walk(unicode(name)):
+                for root, directories, children in os.walk(name):
                     filenames += [os.path.join(root, f) for f in children
                                   if f.endswith('.py') and
                                   not f.startswith('.')]

--- a/test_fuzz_pypi.py
+++ b/test_fuzz_pypi.py
@@ -16,7 +16,7 @@ TMP_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)),
 def latest_packages(last_hours):
     """Return names of latest released packages on PyPI."""
     process = subprocess.Popen(
-        ['yolk', '--latest-releases={hours}'.format(hours=last_hours)],
+        ['yolk', f'--latest-releases={last_hours}'],
         stdout=subprocess.PIPE)
 
     for line in process.communicate()[0].decode('utf-8').split('\n'):
@@ -29,7 +29,7 @@ def download_package(name, output_directory):
 
     Raise CalledProcessError on failure.
     """
-    subprocess.check_call(['yolk', '--fetch-package={name}'.format(name=name)],
+    subprocess.check_call(['yolk', f'--fetch-package={name}'],
                           cwd=output_directory)
 
 
@@ -41,14 +41,14 @@ def extract_package(path, output_directory):
             tar.extractall(path=output_directory)
             tar.close()
             return True
-        except (tarfile.ReadError, IOError):
+        except (tarfile.ReadError, OSError):
             return False
     elif path.lower().endswith('.zip'):
         try:
             archive = zipfile.ZipFile(path)
             archive.extractall(path=output_directory)
             archive.close()
-        except (zipfile.BadZipfile, IOError):
+        except (zipfile.BadZipfile, OSError):
             return False
         return True
 


### PR DESCRIPTION
Python 3.6 (and 2) are no longer supported, so we can require Python 3.7
and drop all the legacy stuff.

Closes #111.