### PR TITLE
Remove lib2to3 usage

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -865,8 +865,7 @@ def detect_encoding(filename, limit_byte_check=-1):
 def _detect_encoding(readline):
     """Return file encoding."""
     try:
-        from lib2to3.pgen2 import tokenize as lib2to3_tokenize
-        encoding = lib2to3_tokenize.detect_encoding(readline)[0]
+        encoding = tokenize.detect_encoding(readline)[0]
         return encoding
     except (LookupError, SyntaxError, UnicodeDecodeError):
         return 'latin-1'


### PR DESCRIPTION
`lib2to3` is deprecated and might not be able to fully parse Python 3.10. Remove it in favor of `tokenize.detect_encoding`.
https://docs.python.org/3/library/2to3.html?module-lib2to3#module-lib2to3