### PR TITLE
Add option to keep pass statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the standard library. (Other modules may have side effects that make them
 unsafe to remove automatically.) Removal of unused variables is also disabled
 by default.
 
-autoflake also removes useless ``pass`` statements.
+autoflake also removes useless ``pass`` statements by default.
 
 ## Example
 
@@ -106,6 +106,10 @@ options:
                         remove all unused imports (not just those from the standard library)
   --ignore-init-module-imports
                         exclude __init__.py when removing unused imports
+  --ignore-pass-statements
+                        keep all `pass` statements
+  --ignore-pass-after-docstring
+                        keep `pass` statements after a new line ending on """
   --remove-duplicate-keys
                         remove all duplicate keys in objects
   --remove-unused-variables


### PR DESCRIPTION
Changes in this PR:
- Add two flags to customize autoflake's behavior for pass statements:
        - ignore-pass-statements: allows the user to opt out of the removal of useless pass statements if desired.
        - ignore-pass-after-docstring: allows the user to keep pass statements after a docstring (see below for caveat).
- Add tests for new flags.
- Update README.

Caveat: since autoflake does not use an AST, deciding whether a pass statement follows a docstring is not really possible (at least not with a LOT of effort), so the approach is to keep pass statements right after a line ending with triple quotes. This is most probably in 99% of the cases a pass after a docstring.

This adds the possibility of keeping pass statements after docstrings which are not useless and is one of the requested features in the repo, see https://github.com/PyCQA/autoflake/issues/73, https://github.com/PyCQA/autoflake/issues/10. I know that autoflake will already keep the pass statement if:

- I leave an empty line after the docstring, but this goes against [PEP 0257](https://peps.python.org/pep-0257/),
- or if I use a docstring format which uses # instead of triple-quotes, which is not the case for anyone using [Google Style Docstring](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)

Closes #9.
Closes #10.
Closes #73.