### PR TITLE
Unified output to stdout when using --check

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -961,7 +961,7 @@ def _fix_file(
         standard_out.write(filtered_source)
     else:
         if args["check"] and not args["quiet"]:
-            standard_out.write(f"No issues detected!{os.linesep}")
+            standard_out.write(f"{filename}: No issues detected!{os.linesep}")
         else:
             _LOGGER.debug("Clean %s: nothing to fix", filename)
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2081,7 +2081,7 @@ except ImportError:
                 standard_error=None,
             )
             self.assertEqual(
-                f"No issues detected!{os.linesep}",
+                f"{filename}: No issues detected!{os.linesep}",
                 output_file.getvalue(),
             )
 
@@ -2100,7 +2100,7 @@ print(x)
                 standard_error=None,
             )
             self.assertEqual(
-                f"No issues detected!{os.linesep}",
+                f"{filename}: No issues detected!{os.linesep}",
                 output_file.getvalue(),
             )
 


### PR DESCRIPTION
This small change unifies the output when running autoflake with --check. Previously one could not know which files passed the checks. Now the output to stdout is unified with the output when a file doesn't pass the check.