### PR TITLE
Add --check-diff flag which combines check and diff

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1396,12 +1396,6 @@ def _main(argv, standard_out, standard_error, standard_input=None) -> int:
         )
         return 1
 
-    # if args.check and args.check_diff:
-    #     _LOGGER.error(
-    #         "Using both --check and --check-diff is invalid, use --check "
-    #         "for less verbose output and --check-diff for diff output",
-    #     )
-
     if args.exclude:
         args.exclude = _split_comma_separated(args.exclude)
     else:

--- a/autoflake.py
+++ b/autoflake.py
@@ -1243,13 +1243,14 @@ def _main(argv, standard_out, standard_error, standard_input=None) -> int:
     import argparse
 
     parser = argparse.ArgumentParser(description=__doc__, prog="autoflake")
-    parser.add_argument(
+    check_group = parser.add_mutually_exclusive_group()
+    check_group.add_argument(
         "-c",
         "--check",
         action="store_true",
         help="return error code if changes are needed",
     )
-    parser.add_argument(
+    check_group.add_argument(
         "-cd",
         "--check-diff",
         action="store_true",
@@ -1395,11 +1396,11 @@ def _main(argv, standard_out, standard_error, standard_input=None) -> int:
         )
         return 1
 
-    if args.check and args.check_diff:
-        _LOGGER.error(
-            "Using both --check and --check-diff is invalid, use --check "
-            "for less verbose output and --check-diff for diff output",
-        )
+    # if args.check and args.check_diff:
+    #     _LOGGER.error(
+    #         "Using both --check and --check-diff is invalid, use --check "
+    #         "for less verbose output and --check-diff for diff output",
+    #     )
 
     if args.exclude:
         args.exclude = _split_comma_separated(args.exclude)

--- a/autoflake.py
+++ b/autoflake.py
@@ -1398,7 +1398,7 @@ def _main(argv, standard_out, standard_error, standard_input=None) -> int:
     if args.check and args.check_diff:
         _LOGGER.error(
             "Using both --check and --check-diff is invalid, use --check "
-            "for less verbose output and --check-diff for diff output"
+            "for less verbose output and --check-diff for diff output",
         )
 
     if args.exclude:

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2252,12 +2252,12 @@ except ImportError:
             )
             self.assertEqual(exit_status, 1)
             self.assertEqual(
-                    """\
+                """\
  import foo
  x = foo
 -import subprocess
  x()
- 
+
  try:
      pass
 -    import os
@@ -2266,8 +2266,8 @@ except ImportError:
 -    import os
 -    import sys
 """,
-                    "\n".join(output_file.getvalue().split("\n")[3:]),
-                )
+                "\n".join(output_file.getvalue().split("\n")[3:]),
+            )
 
     def test_in_place_with_empty_file(self):
         line = ""

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2197,7 +2197,7 @@ print(x)
         ) as filename:
             output_file = io.StringIO()
             autoflake._main(
-                argv=["my_fake_program", "--check", filename],
+                argv=["my_fake_program", "--check-diff", filename],
                 standard_out=output_file,
                 standard_error=None,
             )

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2234,7 +2234,6 @@ import foo
 x = foo
 import subprocess
 x()
-
 try:
     pass
     import os
@@ -2257,7 +2256,6 @@ except ImportError:
  x = foo
 -import subprocess
  x()
-
  try:
      pass
 -    import os


### PR DESCRIPTION
This change adds a new flag which makes it possible to get the power of --check and its exit codes but also a diff output to stdout. This was requested in an issue and seems like a good addition. Added new keyword to keep backwards compatibility. #110 