### PR TITLE
Update merge_configuration_file to prefer values from flags

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1245,8 +1245,9 @@ def merge_configuration_file(args):
                         name,
                     )
                     return False
-                if value:
-                    setattr(args, name.replace("-", "_"), value)
+                arg = name.replace("-", "_")
+                if value and not hasattr(args, arg):
+                    setattr(args, arg, value)
             else:
                 _LOGGER.error("'%s' is not a valid configuration option", name)
                 return False

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3430,6 +3430,30 @@ class ConfigFileTest(unittest.TestCase):
             {"files": files, "imports": "my_lib,other_lib", "config_file": None},
         )
 
+    def test_merge_doesnt_override_existing_attributes(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            "[tool.autoflake]\ncheck = false\n",
+        )
+        files = [self.effective_path("test_me.py")]
+        args = Namespace(
+            files=files,
+            imports="other_lib",
+            config_file=None,
+            check=True,
+        )
+        assert autoflake.merge_configuration_file(args)
+        self.assert_namespace(
+            args,
+            {
+                "files": files,
+                "imports": "other_lib",
+                "config_file": None,
+                "check": True,
+            },
+        )
+
 
 @contextlib.contextmanager
 def temporary_file(contents, directory=".", suffix=".py", prefix=""):


### PR DESCRIPTION
The idea is that options set with flags take precedence over options set in the configuration file (any configuration file).