### PR TITLE
Fix default value for `--imports`

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -924,7 +924,7 @@ def _fix_file(
 
     filtered_source = fix_code(
         source,
-        additional_imports=args.get("imports", "").split(","),
+        additional_imports=(args["imports"].split(",") if "imports" in args else None),
         expand_star_imports=args["expand_star_imports"],
         remove_all_unused_imports=args["remove_all_unused_imports"],
         remove_duplicate_keys=args["remove_duplicate_keys"],

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2638,6 +2638,26 @@ print(x)
             "\n".join(stdout.decode().split(os.linesep)),
         )
 
+    def test_end_to_end_dont_remove_unused_imports_when_not_using_flag(self):
+        with temporary_file(
+            """\
+from . import fake_bar
+from . import fake_foo
+fake_foo.fake_function()
+""",
+        ) as filename:
+            process = subprocess.Popen(
+                AUTOFLAKE_COMMAND
+                + [
+                    filename,
+                ],
+                stdout=subprocess.PIPE,
+            )
+            self.assertEqual(
+                "",
+                "\n".join(process.communicate()[0].decode().split(os.linesep)[3:]),
+            )
+
 
 class MultilineFromImportTests(unittest.TestCase):
     def test_is_over(self):


### PR DESCRIPTION
This was generating a list with the empty string, which caused it to match any import as a glob.

Closes #169.