### PR TITLE
Fixed multiprocessing issue on win64 with more than 60 cores

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1453,7 +1453,11 @@ def _main(argv, standard_out, standard_error, standard_input=None) -> int:
         args["exclude"] = set()
 
     if args["jobs"] < 1:
-        args["jobs"] = os.cpu_count() or 1
+        worker_count = os.cpu_count()
+        if sys.platform == "win32":
+            # Work around https://bugs.python.org/issue26903
+            worker_count = min(worker_count, 60)
+        args["jobs"] = worker_count or 1
 
     filenames = list(set(args["files"]))
 


### PR DESCRIPTION
When running autoflake on win64 with more than 60 cores the following error is encountered

```
> autoflake -c -r .\src
Exception in thread Thread-1:
Traceback (most recent call last):
  File "c:\python\lib\threading.py", line 932, in _bootstrap_inner
    self.run()
  File "c:\python\lib\threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "c:\python\lib\multiprocessing\pool.py", line 519, in _handle_workers
    cls._wait_for_updates(current_sentinels, change_notifier)
  File "c:\python\lib\multiprocessing\pool.py", line 499, in _wait_for_updates
    wait(sentinels, timeout=timeout)
  File "c:\python\lib\multiprocessing\connection.py", line 879, in wait
    ready_handles = _exhaustive_wait(waithandle_to_obj.keys(), timeout)
  File "c:\python\lib\multiprocessing\connection.py", line 811, in _exhaustive_wait
    res = _winapi.WaitForMultipleObjects(L, False, timeout)
ValueError: need at most 63 handles, got a sequence of length 66
```

The issue seems to have already affected projects like Black, see https://github.com/psf/black/pull/1912/files, this pull request is simply porting the same fix.