### PR TITLE
fix: Ignore pass multiple lines after docstring with flag

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -776,18 +776,18 @@ def useless_pass_line_numbers(
 
             is_trailing_pass = (
                 previous_token_type != tokenize.INDENT
-                and not previous_lines[1].rstrip().endswith("\\")
+                and not previous_lines[-1].rstrip().endswith("\\")
             )
 
             is_pass_after_docstring = (
                 # previous line is the end of a docstring
                 previous_token_type == tokenize.NEWLINE
-                and previous_lines[1].rstrip().endswith(("'''", '"""'))
+                and previous_lines[-1].rstrip().endswith(("'''", '"""'))
             ) or (
                 # previous line contains only space and the line before that is
                 # the end of a docstring
-                previous_lines[1].strip() == ""
-                and previous_lines[0].rstrip().endswith(("'''", '"""'))
+                previous_lines[-1].strip() == ""
+                and previous_lines[-2].rstrip().endswith(("'''", '"""'))
             )
 
             # Trailing "pass".

--- a/autoflake.py
+++ b/autoflake.py
@@ -780,7 +780,9 @@ def useless_pass_line_numbers(
                 and not previous_line.rstrip().endswith("\\")
             )
 
-            is_pass_after_docstring = previous_non_empty_line.rstrip().endswith(("'''", '"""'))
+            is_pass_after_docstring = previous_non_empty_line.rstrip().endswith(
+                ("'''", '"""'),
+            )
 
             # Trailing "pass".
             if is_trailing_pass:

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1423,6 +1423,11 @@ print(a)
             \"\"\" A docstring. \"\"\"
 
             pass
+        def foo3():
+            \"\"\" A docstring. \"\"\"
+
+
+            pass
         def bar():
             # abc
             pass
@@ -1456,6 +1461,11 @@ print(a)
             \"\"\" A docstring. \"\"\"
 
             pass
+        def foo3():
+            \"\"\" A docstring. \"\"\"
+
+
+            pass
         def bar():
             # abc
             pass
@@ -1477,6 +1487,11 @@ print(a)
             pass
         def foo2():
             \"\"\" A docstring. \"\"\"
+
+            pass
+        def foo3():
+            \"\"\" A docstring. \"\"\"
+
 
             pass
         def bar():

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -1419,6 +1419,10 @@ print(a)
         def foo():
             \"\"\" A docstring. \"\"\"
             pass
+        def foo2():
+            \"\"\" A docstring. \"\"\"
+
+            pass
         def bar():
             # abc
             pass
@@ -1448,6 +1452,10 @@ print(a)
         def foo():
             \"\"\" A docstring. \"\"\"
             pass
+        def foo2():
+            \"\"\" A docstring. \"\"\"
+
+            pass
         def bar():
             # abc
             pass
@@ -1466,6 +1474,10 @@ print(a)
     else:
         def foo():
             \"\"\" A docstring. \"\"\"
+            pass
+        def foo2():
+            \"\"\" A docstring. \"\"\"
+
             pass
         def bar():
             # abc


### PR DESCRIPTION
Fixes #176 

* Updates `useless_pass_line_numbers` to ignore `pass` after a docstring when `--ignore-pass-after-docstring` is used, even if there are empty lines between the docstring and the pass.

Example where pass will be ignored by `--ignore-pass-after-docstring` when it was not previously:

```py
class MyException(Exception):
    """Example class

    This is an example docstring for the class.
    """

    pass
```