### PR TITLE
Add upper limit to pyflake's version <3.0 to support handling of python 2.x ``# type: `` comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 keywords = ["clean", "fix", "automatic", "unused", "import"]
 urls = { Homepage = "https://www.github.com/PyCQA/autoflake" }
 requires-python = ">=3.7"
-dependencies = ["pyflakes>=1.1.0", "tomli>=2.0.1;python_version<'3.11'"]
+dependencies = ["pyflakes>=1.1.0,<3", "tomli>=2.0.1;python_version<'3.11'"]
 dynamic = ["version"]
 
 [project.readme]


### PR DESCRIPTION
The latest pyflake version removed handling of python 2.x ``# type:`` comments. As the dependency was not upper limited in release of autoflake, none of the available release of autoflake handle's 2.X style typing. It would be very convenient to have a last release that support it in autoflake before allowing pyflake > 3.0 again. 