### PR TITLE
Don't sort imports

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -470,7 +470,7 @@ def filter_from_import(line, unused_module):
 
     indentation += "import "
 
-    return indentation + ", ".join(sorted(filtered_imports)) + get_line_ending(line)
+    return indentation + ", ".join(filtered_imports) + get_line_ending(line)
 
 
 def break_up_import(line):
@@ -496,7 +496,7 @@ def break_up_import(line):
     assert newline
 
     return "".join(
-        [indentation + i.strip() + newline for i in sorted(imports.split(","))],
+        [indentation + i.strip() + newline for i in imports.split(",")],
     )
 
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -601,13 +601,13 @@ import os, math, subprocess
 
     def test_break_up_import(self):
         self.assertEqual(
-            "import abc\nimport math\nimport subprocess\n",
+            "import abc\nimport subprocess\nimport math\n",
             autoflake.break_up_import("import abc, subprocess, math\n"),
         )
 
     def test_break_up_import_with_indentation(self):
         self.assertEqual(
-            "    import abc\n    import math\n    import subprocess\n",
+            "    import abc\n    import subprocess\n    import math\n",
             autoflake.break_up_import("    import abc, subprocess, math\n"),
         )
 
@@ -620,7 +620,7 @@ import os, math, subprocess
     def test_filter_from_import_no_remove(self):
         self.assertEqual(
             """\
-    from foo import abc, math, subprocess\n""",
+    from foo import abc, subprocess, math\n""",
             autoflake.filter_from_import(
                 "    from foo import abc, subprocess, math\n",
                 unused_module=[],
@@ -630,7 +630,7 @@ import os, math, subprocess
     def test_filter_from_import_remove_module(self):
         self.assertEqual(
             """\
-    from foo import math, subprocess\n""",
+    from foo import subprocess, math\n""",
             autoflake.filter_from_import(
                 "    from foo import abc, subprocess, math\n",
                 unused_module=["foo.abc"],


### PR DESCRIPTION
When removing unused imports or breaking up lines, keep the original order.

Users can use other linters/formatters to fix import order (e.g. isort or reorder-python-imports).

Closes #229.