### PR TITLE
feat: allow setting 'files' argument in the config file

### DIFF
--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3508,6 +3508,20 @@ class ConfigFileTest(unittest.TestCase):
             check=True,
         )
 
+    def test_files_from_config(self):
+        self.create_file("test_me.py")
+        self.create_file(
+            "pyproject.toml",
+            '[tool.autoflake]\nfiles=["test_me.py"]\n',
+        )
+        flag_args = dict()
+        with contextlib.chdir(self.tmpdir):
+            args, success = autoflake.merge_configuration_file(flag_args)
+        assert success is True
+        assert args == self.with_defaults(
+            files=["test_me.py"],
+        )
+
 
 @contextlib.contextmanager
 def temporary_file(contents, directory=".", suffix=".py", prefix=""):


### PR DESCRIPTION
As mentioned in #239, theses changes allow passing the 'files' argument in the config file, calling `autoflake` without any arguments. The config file is then searched in the current working directory.

This might be useful e.g. in a CI context, where `autoflake` is called from a shared template with fixed arguments, but source folder layout varies between different repositories.