### PR TITLE
Support .toml configuration format with --config flag

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1194,7 +1194,11 @@ def merge_configuration_file(flag_args):
 
     if "config_file" in flag_args:
         config_file = pathlib.Path(flag_args["config_file"]).resolve()
-        config = process_config_file(config_file)
+
+        if config_file.suffix == ".toml":
+            config = process_pyproject_toml(config_file)
+        else:
+            config = process_config_file(config_file)
 
         if not config:
             _LOGGER.error(

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3385,6 +3385,28 @@ class ConfigFileTest(unittest.TestCase):
                 check=True,
             )
 
+    def test_config_option_toml(self):
+        with temporary_file(
+            suffix=".toml",
+            contents=("[tool.autoflake]\n" "check = true\n" "exclude = [\n  \"build\",\n  \".venv\",\n]"),
+        ) as temp_config:
+            self.create_file("test_me.py")
+            files = [self.effective_path("test_me.py")]
+
+            args, success = autoflake.merge_configuration_file(
+                {
+                    "files": files,
+                    "config_file": temp_config,
+                },
+            )
+            assert success is True
+            assert args == self.with_defaults(
+                files=files,
+                config_file=temp_config,
+                check=True,
+                exclude="build,.venv",
+            )
+
     def test_load_false(self):
         self.create_file("test_me.py")
         self.create_file(

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3388,7 +3388,11 @@ class ConfigFileTest(unittest.TestCase):
     def test_config_option_toml(self):
         with temporary_file(
             suffix=".toml",
-            contents=("[tool.autoflake]\n" "check = true\n" "exclude = [\n  \"build\",\n  \".venv\",\n]"),
+            contents=(
+                "[tool.autoflake]\n"
+                "check = true\n"
+                'exclude = [\n  "build",\n  ".venv",\n]'
+            ),
         ) as temp_config:
             self.create_file("test_me.py")
             files = [self.effective_path("test_me.py")]


### PR DESCRIPTION
Fixes #193 

Adds support for a TOML-formatted configuration file when using the `--config` command line argument.

Currently, passing a TOML file into the `--config` argument results in this error:

```sh
autoflake --config ./path/to/pyproject.toml test_me.py

#  File "[...]/.local/share/pyenv/versions/3.11.2/lib/python3.11/configparser.py", line 1132, in _read
#    raise e
# configparser.ParsingError: Source contains parsing errors: PosixPath('./path/to/pyproject.toml')
```

