### PR TITLE
Revert "Support .toml configuration format with --config flag (#249)"

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1194,11 +1194,7 @@ def merge_configuration_file(flag_args):
 
     if "config_file" in flag_args:
         config_file = pathlib.Path(flag_args["config_file"]).resolve()
-
-        if config_file.suffix == ".toml":
-            config = process_pyproject_toml(config_file)
-        else:
-            config = process_config_file(config_file)
+        config = process_config_file(config_file)
 
         if not config:
             _LOGGER.error(

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3385,32 +3385,6 @@ class ConfigFileTest(unittest.TestCase):
                 check=True,
             )
 
-    def test_config_option_toml(self):
-        with temporary_file(
-            suffix=".toml",
-            contents=(
-                "[tool.autoflake]\n"
-                "check = true\n"
-                'exclude = [\n  "build",\n  ".venv",\n]'
-            ),
-        ) as temp_config:
-            self.create_file("test_me.py")
-            files = [self.effective_path("test_me.py")]
-
-            args, success = autoflake.merge_configuration_file(
-                {
-                    "files": files,
-                    "config_file": temp_config,
-                },
-            )
-            assert success is True
-            assert args == self.with_defaults(
-                files=files,
-                config_file=temp_config,
-                check=True,
-                exclude="build,.venv",
-            )
-
     def test_load_false(self):
         self.create_file("test_me.py")
         self.create_file(


### PR DESCRIPTION
This introduced a breaking change (#251).

This reverts commit 780b44f036ab8715d1299b74b4fd3c7f04e8ed4f.