### PR TITLE
Add support for passing the .toml config in the arguments

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1252,7 +1252,11 @@ def merge_configuration_file(
 
     if "config_file" in flag_args:
         config_file = pathlib.Path(flag_args["config_file"]).resolve()
-        config = process_config_file(str(config_file))
+        process_method = process_config_file
+        if config_file.suffix == ".toml":
+            process_method = process_pyproject_toml
+
+        config = process_method(str(config_file))
 
         if not config:
             _LOGGER.error(

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3389,6 +3389,28 @@ class ConfigFileTest(unittest.TestCase):
                 check=True,
             )
 
+    def test_merge_configuration_file__toml_config_option(self) -> None:
+        with temporary_file(
+            suffix=".toml",
+            contents=("[tool.autoflake]\n" "check = true\n"),
+        ) as temp_config:
+            self.create_file("test_me.py")
+            files = [self.effective_path("test_me.py")]
+
+            args, success = autoflake.merge_configuration_file(
+                {
+                    "files": files,
+                    "config_file": temp_config,
+                },
+            )
+
+            assert success is True
+            assert args == self.with_defaults(
+                files=files,
+                config_file=temp_config,
+                check=True,
+            )
+
     def test_load_false(self) -> None:
         self.create_file("test_me.py")
         self.create_file(


### PR DESCRIPTION
Closes #283 

Add support for passing the .toml config file in the `--config` argument.

`autoflake --config=test.toml file.py`