### PR TITLE
Add support of ignore comment on the top of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ options:
   -s, --stdout          print changed text to stdout. defaults to true when formatting stdin, or to false otherwise
 ```
 
+To ignore the file, you can also add a comment to the top of the file:
+```python
+# autoflake: skip_file
+import os
+```
 
 ## Configuration
 

--- a/autoflake.py
+++ b/autoflake.py
@@ -63,6 +63,11 @@ PYTHON_SHEBANG_REGEX = re.compile(r"^#!.*\bpython[3]?\b\s*$")
 
 MAX_PYTHON_FILE_DETECTION_BYTES = 1024
 
+IGNORE_COMMENT_REGEX = re.compile(
+    r"\s*#\s{1,}autoflake:\s{1,}\bskip_file\b",
+    re.MULTILINE,
+)
+
 
 def standard_paths() -> Iterable[str]:
     """Yield paths to standard modules."""
@@ -902,6 +907,9 @@ def fix_code(
 ) -> str:
     """Return code with all filtering run on it."""
     if not source:
+        return source
+
+    if IGNORE_COMMENT_REGEX.search(source):
         return source
 
     # pyflakes does not handle "nonlocal" correctly.

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2031,7 +2031,9 @@ x = 1
     def test_skip_file_with_shebang_respect(self) -> None:
         skipped_file_file_text = """
 #!/usr/bin/env python3
+
 # autoflake: skip_file
+
 import re
 import os
 import my_own_module

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -2008,6 +2008,47 @@ class SystemTests(unittest.TestCase):
 
     """System tests."""
 
+    def test_skip_file(self) -> None:
+        skipped_file_file_text = """
+# autoflake: skip_file
+import re
+import os
+import my_own_module
+x = 1
+"""
+        with temporary_file(skipped_file_file_text) as filename:
+            output_file = io.StringIO()
+            autoflake._main(
+                argv=["my_fake_program", filename, "--stdout"],
+                standard_out=output_file,
+                standard_error=None,
+            )
+            self.assertEqual(
+                skipped_file_file_text,
+                output_file.getvalue(),
+            )
+
+    def test_skip_file_with_shebang_respect(self) -> None:
+        skipped_file_file_text = """
+#!/usr/bin/env python3
+# autoflake: skip_file
+import re
+import os
+import my_own_module
+x = 1
+"""
+        with temporary_file(skipped_file_file_text) as filename:
+            output_file = io.StringIO()
+            autoflake._main(
+                argv=["my_fake_program", filename, "--stdout"],
+                standard_out=output_file,
+                standard_error=None,
+            )
+            self.assertEqual(
+                skipped_file_file_text,
+                output_file.getvalue(),
+            )
+
     def test_diff(self) -> None:
         with temporary_file(
             """\


### PR DESCRIPTION
Autoflake can now ignore files with the `# autoflake: ignore` comment on top.
Closes #97 