### PR TITLE
Always set encoding when reading `setup.cfg`

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -1209,7 +1209,7 @@ def process_config_file(config_file_path: str) -> MutableMapping[str, Any] | Non
     import configparser
 
     reader = configparser.ConfigParser()
-    reader.read(config_file_path)
+    reader.read(config_file_path, encoding="utf-8")
     if not reader.has_section("autoflake"):
         return None
 


### PR DESCRIPTION
This should fix an issue on Window where the `setup.cfg` can contain non-ascii characters, and Python is trying to use cp1252. This should be safe as utf-8 is compatible with cp1252.

It's possible I'll eat my words and some other platform breaks with this change, but let's try.

Closes #294.