### PR TITLE
fix: handle missing 'import' keyword in break_up_import

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -533,12 +533,17 @@ def break_up_import(line: str) -> str:
     if not newline:
         return line
 
-    indentation, imports = re.split(
+    parts = re.split(
         pattern=r"\bimport\b",
         string=line,
         maxsplit=1,
     )
 
+    if len(parts) != 2:
+        # No 'import' keyword found (e.g., a continuation line with \r line endings)
+        return line
+
+    indentation, imports = parts
     indentation += "import "
     assert newline
 

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -3619,3 +3619,23 @@ class StubFile:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCarriageReturnInImport(unittest.TestCase):
+    """Tests for fix of crash with carriage return in multiline import (issue #326)."""
+
+    def test_carriage_return_in_multiline_parenthesized_import(self):
+        """Should not crash when a line within parenthesized import starts with \r."""
+        source = (
+            "from t import (\n"
+            "\r  a,\n"
+            "    b,\n"
+            ")\n"
+            "from t import (\n"
+            "    a,\n"
+            "    b,\n"
+            ")\n"
+        )
+        # Should not raise ValueError
+        result = autoflake.fix_code(source, remove_all_unused_imports=True)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
## Problem

When source code contains carriage returns (\`\r\`) within parenthesized import statements, `io.StringIO.readlines()` may produce continuation lines that don't contain the `import` keyword. When `break_up_import()` is called on such a line, `re.split(r'\bimport\b', line)` returns only one element, and unpacking to `(indentation, imports)` raises:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

Reproducible with:
```python
import autoflake
s = '''
from t import (
\r  a,
    b,
)
from t import (
    a,
    b,
)
'''
autoflake.fix_code(s, remove_all_unused_imports=True)  # raises ValueError
```

## Fix

In `break_up_import()`, check the number of parts returned by `re.split()`. If `'import'` is not found in the line (i.e., it's a bare continuation line), return the line unchanged.

## Tests

Added `TestCarriageReturnInImport` test class verifying the fix.

Fixes #326