### PR TITLE
add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Software Development :: Quality Assurance",
+  "Typing :: Typed",
 ]
 keywords = ["clean", "fix", "automatic", "unused", "import"]
 urls = { Homepage = "https://www.github.com/PyCQA/autoflake" }


### PR DESCRIPTION
Prevents `Stub file not found for "autoflake" Pylance (reportMissingTypeStubs)`.