### PR TITLE
fix: crash on backslash-continuation where `import` is on the second line

### DIFF
--- a/autoflake.py
+++ b/autoflake.py
@@ -386,7 +386,17 @@ class FilterMultilineImport(PendingFix):
         """Receive the same parameters as ``filter_unused_import``."""
         self.remove: Iterable[str] = unused_module
         self.parenthesized: bool = "(" in line
-        self.from_, imports = self.IMPORT_RE.split(line, maxsplit=1)
+        split = self.IMPORT_RE.split(line, maxsplit=1)
+        if len(split) == 1:
+            # ``import`` is on a continuation line (e.g. ``from X \<newline>
+            #     import Y``).  Treat the whole first line as the ``from``
+            # fragment and leave imports empty; give_up ensures the statement
+            # is passed through unchanged.
+            self.from_, imports = line, ""
+            self.give_up_no_import_on_first_line: bool = True
+        else:
+            self.from_, imports = split
+            self.give_up_no_import_on_first_line = False
         match = self.BASE_RE.search(self.from_)
         self.base = match.group(1) if match else None
         self.give_up: bool = False
@@ -399,6 +409,10 @@ class FilterMultilineImport(PendingFix):
 
         if "\\" in previous_line:
             # Ignore tricky things like "try: \<new line> import" ...
+            self.give_up = True
+
+        if self.give_up_no_import_on_first_line:
+            # ``import`` is deferred to a continuation line; cannot filter.
             self.give_up = True
 
         self.analyze(line)
@@ -470,6 +484,10 @@ class FilterMultilineImport(PendingFix):
         if not self.is_over(line):
             return self
         if self.give_up:
+            if self.give_up_no_import_on_first_line:
+                # The ``import`` keyword was not on the first line; reconstruct
+                # verbatim without inserting a spurious ``import``.
+                return self.from_ + "".join(self.accumulator)
             return self.from_ + "import " + "".join(self.accumulator)
 
         return self.fix(self.accumulator)

--- a/test_autoflake.py
+++ b/test_autoflake.py
@@ -717,6 +717,29 @@ isdir('42')
             ),
         )
 
+    def test_filter_code_backslash_continuation_import_on_second_line(
+        self,
+    ) -> None:
+        """Backslash-continuation where 'import' appears on the second line.
+
+        ``from X \\<newline>    import A, B`` is a valid Python multiline
+        import.  autoflake used to crash with ``ValueError: not enough values
+        to unpack`` because the regex split expected ``import`` on the first
+        line.  The statement must be passed through unchanged (give_up path).
+        """
+        source = "".join(
+            [
+                "from ci.zimbeast.test_scripts.framework.test_interrupt.seq_lib \\\n",
+                "    import IntTestSequence, send_int\n",
+                "\n",
+                "x = send_int(1)\n",
+            ]
+        )
+        self.assertEqual(
+            source,
+            "".join(autoflake.filter_code(source, remove_all_unused_imports=True)),
+        )
+
     def test_filter_code_should_ignore_semicolons(self) -> None:
         self.assertEqual(
             r"""\


### PR DESCRIPTION
Fixes #259.

## Problem

`FilterMultilineImport.__init__` splits the first line on `\bimport\b`
to separate the `from X` fragment from the imported names.  For the
valid Python pattern

```python
from very.long.module.path \
    import SomeName, OtherName
```

the **first** line contains no `import` keyword, so
`IMPORT_RE.split(line, maxsplit=1)` returns a one-element list.
Unpacking that into two variables raised:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

## Fix

Detect the one-element result, assign `self.from_ = line` and
`imports = ""`, and set `give_up = True` so the entire statement is
passed through unchanged.  The `__call__` give-up return path is also
fixed so it does not spuriously prepend `"import "` in this case.

## Test

Added `test_filter_code_backslash_continuation_import_on_second_line`
which exercises exactly the pattern from the issue report.

```
173 passed in 0.78s
```

This pull request was prepared with the assistance of AI, under my direction and review.